### PR TITLE
Allowing separator to be an empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function insert(texts, separator, type) {
         throw new PluginError(PLUGIN_NAME, 'Missing type !');
     }
 
-    if (!separator) {
+    if (!separator && separator !== '') {
         separator = "\n";
     }
 


### PR DESCRIPTION
I have the use case that there may be no space between the files that I would like to prepend. This PR allows to make sure that we can use `''` as separator in append/prepend calls.