### PR TITLE
Integrate with travis ci for build status badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+    - node
+    - "10"

--- a/README.MD
+++ b/README.MD
@@ -2,6 +2,10 @@
 
 Simple Gulp plugin.
 
+[![License:MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/JamesHemery/gulp-append-prepend/blob/master/LICENCE)
+[![npm](https://img.shields.io/npm/v/gulp-append-prepend.svg)](https://www.npmjs.com/package/gulp-append-prepend)
+[![Build](https://travis-ci.org/JamesHemery/gulp-append-prepend.svg)](https://travis-ci.org/JamesHemery/gulp-append-prepend)
+
 ## Usage
 
 First, install gulp-append-prepend as a development dependency:


### PR DESCRIPTION
Creates link to see mocha test output from the last commit.

To enable link, project administrator needs to activate this repository:
https://travis-ci.org/JamesHemery/gulp-append-prepend